### PR TITLE
migrated kyma tutorial to servicemanager

### DIFF
--- a/managed-html5-runtime-jwt-kyma/README.md
+++ b/managed-html5-runtime-jwt-kyma/README.md
@@ -30,28 +30,29 @@ In addition the following service instances are created:
 2. Build and upload the docker image of the backend component
    ```
     cd managed-html5-runtime-jwt-kyma/backend
-    docker build -t iobert/kyma-simple-backend .
-    docker push iobert/kyma-simple-backend
+    docker build -t <yourAccount>/kyma-simple-backend .
+    docker push <yourAccount>/kyma-simple-backend
     ```
-2. Build and upload the docker image of the html5 app deployer 
+1. Build and upload the docker image of the html5 app deployer 
    ```
     cd ../deployer
     docker build -t iobert/kyma-html5-app-deployer .
     docker push iobert/kyma-html5-app-deployer
     ```
-4. Add your account id (e.g. "43de072btrial") to the destination which is defined in the environment variable `BACKEND_DESTINATIONS` of the [deployment descriptor](html5-app-deployer/deployment.yaml).
-2. Deploy the project
+1. Add your <clusterId> (e.g. "c-13093b0") to the destination which is defined in the environment variable `BACKEND_DESTINATIONS` of the [deployment descriptor](./deployment.yaml). You can find the <clusterID> in the entry page of the Kyma dashboard
+1. Deploy the project
    ```
+   cd ..
    kubectl apply -f deployment.yaml
    ```
        
-2. Access the web app via the SAP BTP cockpit or assemble the URL according to the following pattern:
+1. Access the web app via the SAP BTP cockpit or assemble the URL according to the following pattern:
    ```
    https://<account id>.launchpad.cfapps.eu10.hana.ondemand.com/<destination service instance ID>.businessservice.tokendisplay/index.html    ->
    https://43de072btrial.launchpad.cfapps.eu10.hana.ondemand.com/8aebc2e1-2234-4bd1-8da4-e15231138dbf.businessservice.tokendisplay/index.html
    ```
 
-   > You can find the destination service instance ID in the Kyma console
+   > You can find the destination service instance ID in the Kyma dashboard
    ![](instanceId.png)
 
 

--- a/managed-html5-runtime-jwt-kyma/README.md
+++ b/managed-html5-runtime-jwt-kyma/README.md
@@ -36,7 +36,7 @@ In addition the following service instances are created:
 2. Build and upload the docker image of the html5 app deployer 
    ```
     cd ../deployer
-    docker build -t iobert/kyma-html5-app-deployer 
+    docker build -t iobert/kyma-html5-app-deployer .
     docker push iobert/kyma-html5-app-deployer
     ```
 4. Add your account id (e.g. "43de072btrial") to the destination which is defined in the environment variable `BACKEND_DESTINATIONS` of the [deployment descriptor](html5-app-deployer/deployment.yaml).

--- a/managed-html5-runtime-jwt-kyma/deployment.yaml
+++ b/managed-html5-runtime-jwt-kyma/deployment.yaml
@@ -48,7 +48,6 @@ metadata:
   labels:
     app: backend
   name: backend
-  apirule.gateway.kyma-project.io/v1alpha1: backend
 spec:
   gateway: kyma-gateway.kyma-system.svc.cluster.local
   service:
@@ -101,7 +100,7 @@ spec:
               \"Description\":\"my kyma backend\",
               \"Type\":\"HTTP\",
               \"ProxyType\":\"Internet\",
-              \"URL\":\"https://backend.c-13093b0.kyma.shoot.live.k8s-hana.ondemand.com\",
+              \"URL\":\"https://backend.<clusterId>.stage.kyma.ondemand.com\",
               \"Authentication\":\"NoAuthentication\",
               \"HTML5.forwardAuthToken\": true}]"
       volumes:
@@ -116,13 +115,13 @@ spec:
             secretName: kyma-destination-binding
 
 ---
-apiVersion: servicecatalog.k8s.io/v1beta1
+apiVersion: services.cloud.sap.com/v1
 kind: ServiceInstance
 metadata:
   name: kyma-xsuaa-instance
 spec:
-  clusterServiceClassExternalName: xsuaa
-  clusterServicePlanExternalName: application
+  serviceOfferingName: xsuaa
+  servicePlanName: application
   parameters:
     xsappname: kyma-app
     tenant-mode: shared
@@ -154,49 +153,46 @@ spec:
         - https://*/**
 
 ---
-apiVersion: servicecatalog.k8s.io/v1beta1
+apiVersion: services.cloud.sap.com/v1
 kind: ServiceBinding
 metadata:
   name: kyma-xsuaa-binding
 spec:
-  instanceRef:
-    name: kyma-xsuaa-instance
+  serviceInstanceName: kyma-xsuaa-instance
 
 ---
-apiVersion: servicecatalog.k8s.io/v1beta1
+apiVersion: services.cloud.sap.com/v1
 kind: ServiceInstance
 metadata:
   name: kyma-app-host-instance
 spec:
-  clusterServiceClassExternalName: html5-apps-repo
-  clusterServicePlanExternalName: app-host
+  serviceOfferingName: html5-apps-repo
+  servicePlanName: app-host
 
 ---
-apiVersion: servicecatalog.k8s.io/v1beta1
+apiVersion: services.cloud.sap.com/v1
 kind: ServiceBinding
 metadata:
   name: kyma-app-host-binding
 spec:
-  instanceRef:
-    name: kyma-app-host-instance
+  serviceInstanceName: kyma-app-host-instance
 
 ---
-apiVersion: servicecatalog.k8s.io/v1beta1
+apiVersion: services.cloud.sap.com/v1
 kind: ServiceInstance
 metadata:
   name: kyma-destination-instance
 spec:
-  clusterServiceClassExternalName: destination
-  clusterServicePlanExternalName: lite
+  serviceOfferingName: destination
+  servicePlanName: lite
   parameters:
     HTML5Runtime_enabled: true
     version: "1.0.0"
 
 ---
-apiVersion: servicecatalog.k8s.io/v1beta1
+apiVersion: services.cloud.sap.com/v1
 kind: ServiceBinding
 metadata:
   name: kyma-destination-binding
 spec:
-  instanceRef:
-    name: kyma-destination-instance
+  serviceInstanceName: kyma-destination-instance


### PR DESCRIPTION
- fixed some minor things in the readme
- adjusted to use the clusterId in the destinationservice config instead of account id
- migrated the deployment to use the servicemanager resources instead of outdated k8s servicecatalog