### PR TITLE
Set "public": true for sap.cloud to enable Workzone SE deployment

### DIFF
--- a/managed-html5-runtime-basic-mta/HTML5Module/manifest.json
+++ b/managed-html5-runtime-basic-mta/HTML5Module/manifest.json
@@ -9,6 +9,7 @@
     }
   },
   "sap.cloud": {
+    "public": true,
     "service": "basic.service"
   },
   "sap.ui5": {


### PR DESCRIPTION
@nicoschoenteich We used your sample in our project, but had the issue that without the additional parameter for "public": true in sap.cloud the Build Workzone, standard edition was not able to find the HTML5 App. 

![image](https://github.com/SAP-samples/multi-cloud-html5-apps-samples/assets/12248425/efcf7778-2ae5-4d99-95c6-d85d8344c996)

For us this did the trick. If this is not the right way and we misconfigured the Workzone we can also close this one :) 